### PR TITLE
#35021938 Ошибка изменения статуса задач в Kanban.

### DIFF
--- a/LeokaEstetica.Platform.Database.Upgrade/Scripts/253.esta.ddl_alter_project_management_transition_intermediate_templates.sql
+++ b/LeokaEstetica.Platform.Database.Upgrade/Scripts/253.esta.ddl_alter_project_management_transition_intermediate_templates.sql
@@ -1,0 +1,4 @@
+﻿ALTER TABLE templates.project_management_transition_intermediate_templates
+DROP CONSTRAINT IF EXISTS pk_transition_intermediate_templates_transition_id;
+    
+CREATE UNIQUE INDEX ON templates.project_management_transition_intermediate_templates (from_status_id, to_status_id, transition_type);

--- a/LeokaEstetica.Platform.Database/Abstractions/ProjectManagment/IProjectManagmentRepository.cs
+++ b/LeokaEstetica.Platform.Database/Abstractions/ProjectManagment/IProjectManagmentRepository.cs
@@ -215,9 +215,10 @@ public interface IProjectManagmentRepository
     /// </summary>
     /// <param name="currentTaskStatusId">Id текущего статуса задачи.</param>
     /// <param name="transitionType">Тип перехода.</param>
+    /// <param name="templateId">Id шаблона проекта.</param>
     /// <returns>Список переходов.</returns>
     Task<IEnumerable<long>> GetProjectManagementTransitionIntermediateTemplatesAsync(long currentTaskStatusId,
-        TransitionTypeEnum transitionType);
+        TransitionTypeEnum transitionType, int templateId);
 
     /// <summary>
     /// Метод получает статусы из таблицы связей многие-многие, чтобы дальше работать с


### PR DESCRIPTION
Отчасти поправил. Но проблема кроется глубже. Она в том, что эпик и история не могут иметь статусы, которые имеют задачи, ошибки (например ревью, тестирование и тд).

Они либо новые, в работе, закрыты или решены.

Тут нужно в рамках отдельной задачи и отдельно продумывать, как в Kanban (в Scrum только доступные переходы увидим в просмотре, поэтому там этой проблемы не будет) будем запрещать переводить в статусы эпик и историю, кроме доступных статусов (их вроде лишь 4, а на доске их более 4 там). Например модалкой предупреждать, что можно перевести эпик/историю в такие то статусы только. Потому что скрыть лишние статусы на доске не можем, так как там же все разные типы задач и для них другие статусы возможны.