### PR TITLE
Feature/39171111 при сохранение анкеты с пустым полем номера телефона появляются две ошибки

### DIFF
--- a/LeokaEstetica.Platform.Controllers/Profile/ProfileController.cs
+++ b/LeokaEstetica.Platform.Controllers/Profile/ProfileController.cs
@@ -5,6 +5,7 @@ using LeokaEstetica.Platform.Controllers.Validators.Profile;
 using LeokaEstetica.Platform.Models.Dto.Input.Profile;
 using LeokaEstetica.Platform.Models.Dto.Output.Profile;
 using LeokaEstetica.Platform.Services.Abstractions.Profile;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -132,8 +133,8 @@ public class ProfileController : BaseController
             
             var ex = new AggregateException(exceptions);
             _logger.LogError(ex, "Ошибки при попытке сохранения данных профиля.");
-            
-            result.Errors.AddRange(validator.Errors);
+
+            result.Errors.Add(validator.Errors.First());
 
             return result;
         }

--- a/LeokaEstetica.Platform.Controllers/Validators/Profile/SaveProfileInfoValidator.cs
+++ b/LeokaEstetica.Platform.Controllers/Validators/Profile/SaveProfileInfoValidator.cs
@@ -45,6 +45,7 @@ public class SaveProfileInfoValidator : AbstractValidator<ProfileInfoInput>
             .WithMessage(ValidationConsts.EMPTY_PHONE_NUMBER_ERROR)
             .NotEmpty()
             .WithMessage(ValidationConsts.EMPTY_PHONE_NUMBER_ERROR)
-            .Matches(@"^((8|\+7)[\- ]?)?(\(?\d{3}\)?[\- ]?)?[\d\- ]{7,10}$");
+            .Matches(@"^((8|\+7)[\- ]?)?(\(?\d{3}\)?[\- ]?)?[\d\- ]{7,10}$")
+            .WithMessage(ValidationConsts.NOT_VALID_PHONE_NUMBER_ERROR);
     }
 }


### PR DESCRIPTION
Добавлено сообщение на русском о некорректном формате номера
Исправлен баг с несколькими ошибками, теперь появляются в порядке не введен -> не корректен